### PR TITLE
增加concat文件合并方式，避免合并时打开文件过多问题

### DIFF
--- a/M3u8Downloader_H.Plugin.Abstractions/Settings/IMergeSetting.cs
+++ b/M3u8Downloader_H.Plugin.Abstractions/Settings/IMergeSetting.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace M3u8Downloader_H.Abstractions.Settings
+﻿namespace M3u8Downloader_H.Abstractions.Settings
 {
     public interface IMergeSetting
     {
         string SelectedFormat { get; }
         bool ForcedMerger { get; }
         bool IsCleanUp { get; }
+
+        /// <summary>
+        /// 提供选项以确定是否使用Concat列表文件进行合并，以避免一次性打开文件过多报错。
+        /// (对于长影片使用M3U文件时容易出现这种情况。)
+        /// </summary>
+        bool ConcatMerger { get; }
     }
 }

--- a/M3u8Downloader_H/Services/SettingsService.cs
+++ b/M3u8Downloader_H/Services/SettingsService.cs
@@ -66,6 +66,8 @@ namespace M3u8Downloader_H.Services
         [Range(1, 300)]
         public int Timeouts { get; set; } = 30;
 
+        public bool ConcatMerger { get; set; } = true;
+
         public SettingsService()
         {
 #if DEBUG
@@ -93,6 +95,8 @@ namespace M3u8Downloader_H.Services
                 Headers = Headers,
                 RecordDuration = RecordDuration,
                 Timeouts = Timeouts,
+                IsResetName = IsResetName,
+                ConcatMerger = ConcatMerger,
             };
         }
 
@@ -113,6 +117,8 @@ namespace M3u8Downloader_H.Services
             Headers = other.Headers;
             RecordDuration = other.RecordDuration;
             Timeouts = other.Timeouts;
+            IsResetName = other.IsResetName;
+            ConcatMerger = other.ConcatMerger;
         }
 
         public void UpdateConcurrentDownloadCount()

--- a/M3u8Downloader_H/Views/Menus/SettingsView.xaml
+++ b/M3u8Downloader_H/Views/Menus/SettingsView.xaml
@@ -168,6 +168,20 @@
                         <TextBlock  Style="{StaticResource TextBlockStyle}"  Text="强制合并"/>
                         <ToggleButton Name="forceMergerButton"  HorizontalAlignment="Left"  Margin="10 0 0 0" Style="{StaticResource MaterialDesignSwitchToggleButton}"  ToolTip="{Binding ForcedMerger,Converter={x:Static converters:BoolToStringConverters.Instance}}" IsChecked="{Binding ForcedMerger}" />
                     </DockPanel>
+
+                    <DockPanel Margin="8 0" >
+                      <DockPanel.ToolTip>
+                          <TextBlock>
+                              <Run Text="当视频超长，M3U列表片段太多，合并时报打开文件过多的错误时开启"/>
+                              <LineBreak/>
+                              <Run Text="开启后，合并视频时将传入concat列表文件，而不是一次性打开所有片段文件" />
+                              <LineBreak/>
+                              <Run Text="这种方式合并视频稍慢一点，但可避免出错" />
+                          </TextBlock>
+                      </DockPanel.ToolTip>
+                      <TextBlock  Style="{StaticResource TextBlockStyle}" Text="列表合并"/>
+                      <ToggleButton HorizontalAlignment="Left"  Margin="10 0 0 0" Style="{StaticResource MaterialDesignSwitchToggleButton}"  ToolTip="{Binding ConcatMerger,Converter={x:Static converters:BoolToStringConverters.Instance}}" IsChecked="{Binding ConcatMerger}" />
+                  </DockPanel>
                 </WrapPanel>
 
                 <!-- 直播配置区 -->


### PR DESCRIPTION
下载较长的M3U影片，最后ffmpeg合并时报错“ too many open files”，分析是因为使用了“-i concat:1.tmp|2.tmp|3.tmp ...”这种参数一次性将所有文件打开了。改为concat格式文件输入后合并成功，因此增加了该方式合并的可选项。